### PR TITLE
Fix code scanning alert no. 17: Inefficient regular expression

### DIFF
--- a/code/addons/docs/src/compiler/index.test.ts
+++ b/code/addons/docs/src/compiler/index.test.ts
@@ -15,7 +15,7 @@ const clean = (code: string) => {
     /export default function MDXContent\([^)]*\) \{(?:[^{}]*|{(?:[^{}]*|{[^{}]*})*})*\}/gs;
 
   const mdxMissingReferenceRegex =
-    /function _missingMdxReference\([^)]*\) \{(?:[^{}]*|{(?:[^{}]*|{[^{}]*})*})*\}/gs;
+    /function _missingMdxReference\([^)]*\) \{(?:[^{}]*|{(?:[^{}]*|{[^{}]*?})*?})*?\}/gs;
 
   return code.replace(mdxMissingReferenceRegex, '').replace(mdxContentRegex, '');
 };


### PR DESCRIPTION
Fixes [https://github.com/akaday/storybook/security/code-scanning/17](https://github.com/akaday/storybook/security/code-scanning/17)

To fix the problem, we need to modify the regular expression to remove the ambiguity that causes exponential backtracking. This can be achieved by making the inner repetition more specific, ensuring that it does not match in multiple ways. Specifically, we can replace `[^{}]*` with a more precise pattern that avoids nested quantifiers.

- Modify the regular expression on line 18 to use a non-greedy match for the inner content.
- Ensure that the new pattern does not change the existing functionality of the `clean` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
