### PR TITLE
Add test for Title component with undefined of prop

### DIFF
--- a/code/lib/blocks/src/blocks/DocsPage.test.ts
+++ b/code/lib/blocks/src/blocks/DocsPage.test.ts
@@ -1,6 +1,5 @@
-// @vitest-environment happy-dom
 import { describe, expect, it } from 'vitest';
-
+import { Title } from './Title';
 import { extractTitle } from './Title';
 
 describe('defaultTitleSlot', () => {
@@ -8,5 +7,11 @@ describe('defaultTitleSlot', () => {
     expect(extractTitle('a/b/c')).toBe('c');
     expect(extractTitle('a|b')).toBe('a|b');
     expect(extractTitle('a/b/c.d')).toBe('c.d');
+  });
+
+  it('throws error when of prop is undefined', () => {
+    expect(() => {
+      Title({ of: undefined });
+    }).toThrow('Unexpected `of={undefined}`, did you mistype a CSF file reference?');
   });
 });


### PR DESCRIPTION
Add test case for `Title` component to handle undefined `of` prop

* Import `Title` component from `./Title`.
* Add a test case to verify that the `Title` component throws an error when the `of` prop is undefined.
* Use `describe` and `it` functions from `vitest` to define the test case.
* Use `expect` function from `vitest` to assert that the error is thrown.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/storybook/pull/6?shareId=fd28c84d-d8ef-47cc-816e-475e012e899e).