### PR TITLE
Fix code scanning alert no. 4: Server-side URL redirect

### DIFF
--- a/scripts/run-registry.ts
+++ b/scripts/run-registry.ts
@@ -53,7 +53,12 @@ const startVerdaccio = async () => {
       const proxy = http.createServer((req, res) => {
         // if request contains "storybook" redirect to verdaccio
         if (req.url?.includes('storybook') || req.url?.includes('/sb') || req.method === 'PUT') {
-          res.writeHead(302, { Location: 'http://localhost:6002' + req.url });
+          const targetUrl = 'http://localhost:6002' + req.url;
+          if (isLocalUrl(targetUrl)) {
+            res.writeHead(302, { Location: targetUrl });
+          } else {
+            res.writeHead(302, { Location: 'http://localhost:6002' });
+          }
           res.end();
         } else {
           // forward to npm registry
@@ -96,6 +101,14 @@ const startVerdaccio = async () => {
       }, 10000);
     }),
   ]) as Promise<Server>;
+};
+
+const isLocalUrl = (path) => {
+  try {
+    return new URL(path, 'http://localhost:6002').origin === 'http://localhost:6002';
+  } catch (e) {
+    return false;
+  }
 };
 
 const currentVersion = async () => {


### PR DESCRIPTION
Fixes [https://github.com/akaday/storybook/security/code-scanning/4](https://github.com/akaday/storybook/security/code-scanning/4)

To fix the problem, we need to validate the user input before using it in the URL redirection. One way to do this is to ensure that the URL path is local and does not redirect to a different host. We can achieve this by using the `URL` constructor to parse the URL and check its origin.

We will create a helper function `isLocalUrl` to validate the URL and use this function before performing the redirection. If the URL is not valid, we will redirect to a safe default URL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
