### PR TITLE
Verify the path for @storybook/addon-mdx-gfm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,15 @@ commands:
           only_for_branches: main,next,next-release,latest-release
           fail_only: true
           failure_message: $(yarn get-report-message << pipeline.parameters.workflow >> << parameters.template >>)
+  check-network-access:
+    description: "Check network access by pinging a known URL"
+    steps:
+      - run:
+          name: Check network access
+          command: |
+            curl -sSf https://www.google.com > /dev/null
+            echo "Network access verified."
+
 jobs:
   pretty-docs:
     executor:


### PR DESCRIPTION
Add a CircleCI job to check network access by pinging a known URL.

* **Network Access Verification**
  - Add a new job `check-network-access` in `.circleci/config.yml`
  - Include a `curl` command to check connectivity to `https://www.google.com`
  - Output a message "Network access verified" upon successful check

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/storybook/pull/13?shareId=35128def-082b-4222-be74-fb7a34eecd3d).